### PR TITLE
Allow ant-style glob patterns for APKs instead of comma-separated paths

### DIFF
--- a/src/main/resources/fabric/beta/publisher/FabricBetaPublisher/config.jelly
+++ b/src/main/resources/fabric/beta/publisher/FabricBetaPublisher/config.jelly
@@ -12,6 +12,10 @@
         <f:textbox default="app/build/outputs/apk/app-debug.apk"/>
     </f:entry>
 
+    <f:entry title="path as ant-style include" field="useAntStyleInclude">
+        <f:checkbox/>
+    </f:entry>
+
     <f:section title="Notify testers">
         <f:radioBlock name="notifyTestersType" title="Testers group" value="NOTIFY_TESTERS_EMAILS"
                       checked="${instance.isNotifyTestersType('NOTIFY_TESTERS_EMAILS')}" inline="true">

--- a/src/main/resources/fabric/beta/publisher/FabricBetaPublisher/help-useAntStyleInclude.html
+++ b/src/main/resources/fabric/beta/publisher/FabricBetaPublisher/help-useAntStyleInclude.html
@@ -1,0 +1,3 @@
+<div>
+    Interprets the apk path as ant-style include pattern (i.e. supporting glob patterns like * and **) relative to the workspace.
+</div>


### PR DESCRIPTION
This small-ish patch allows to interpret the APK file names as ant-style glob patterns instead of file names, unfortunately without during-edit verification support for now. I added an optional checkbox to enable this behaviour in order to not break possible existing patterns during upgrade for now.