### PR TITLE
Jenkins Pipeline support

### DIFF
--- a/src/main/java/fabric/beta/publisher/FabricBetaPublisher.java
+++ b/src/main/java/fabric/beta/publisher/FabricBetaPublisher.java
@@ -31,6 +31,7 @@ import hudson.model.BuildListener;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.Job;
+import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.scm.ChangeLogSet;
@@ -94,7 +95,9 @@ public class FabricBetaPublisher extends Recorder implements SimpleBuildStep {
                         TaskListener listener) throws InterruptedException, IOException {
         PrintStream logger = listener.getLogger();
         ChangeLogSet<? extends ChangeLogSet.Entry> changeLogSet = getChangeLogSetFromRun(build);
-        publishFabric(build.getEnvironment(listener), workspace, logger, changeLogSet);
+        if (!publishFabric(build.getEnvironment(listener), workspace, logger, changeLogSet)) {
+            build.setResult(Result.FAILURE);
+        }
     }
 
     private boolean publishFabric(EnvVars environment, FilePath workspace, PrintStream logger,
@@ -331,6 +334,26 @@ public class FabricBetaPublisher extends Recorder implements SimpleBuildStep {
     @SuppressWarnings("unused")
     public String isNotifyTestersType(String notifyTestersType) {
         return this.notifyTestersType.equalsIgnoreCase(notifyTestersType) ? "true" : "";
+    }
+
+    @SuppressWarnings("unused")
+    public String getReleaseNotesType() {
+        return releaseNotesType;
+    }
+
+    @SuppressWarnings("unused")
+    public String getNotifyTestersType() {
+        return notifyTestersType;
+    }
+
+    @SuppressWarnings("unused")
+    public String getReleaseNotesParameter() {
+        return releaseNotesParameter;
+    }
+
+    @SuppressWarnings("unused")
+    public String getReleaseNotesFile() {
+        return releaseNotesFile;
     }
 
     @Extension

--- a/src/main/java/fabric/beta/publisher/FabricBetaPublisher.java
+++ b/src/main/java/fabric/beta/publisher/FabricBetaPublisher.java
@@ -93,7 +93,7 @@ public class FabricBetaPublisher extends Recorder implements SimpleBuildStep {
     public void perform(Run build, FilePath workspace, Launcher launcher,
                         TaskListener listener) throws InterruptedException, IOException {
         PrintStream logger = listener.getLogger();
-        ChangeLogSet<? extends ChangeLogSet.Entry> changeLogSet = getChangeLogSetFromRun(build, logger);
+        ChangeLogSet<? extends ChangeLogSet.Entry> changeLogSet = getChangeLogSetFromRun(build);
         publishFabric(build.getEnvironment(listener), workspace, logger, changeLogSet);
     }
 
@@ -119,7 +119,7 @@ public class FabricBetaPublisher extends Recorder implements SimpleBuildStep {
         return !failure;
     }
 
-    private ChangeLogSet<? extends ChangeLogSet.Entry> getChangeLogSetFromRun(Run<?, ?> build, PrintStream logger) {
+    private ChangeLogSet<? extends ChangeLogSet.Entry> getChangeLogSetFromRun(Run<?, ?> build) {
         ItemGroup<?> itemGroup = build.getParent().getParent();
         for (Item item : itemGroup.getItems()) {
             if (!item.getFullDisplayName().equals(build.getFullDisplayName())


### PR DESCRIPTION
Enables support for plugin jenkinsFile usage.

TODO: We need to find a way to get or generate the changelog through Run instead of AbstractBuild.