### PR TITLE
Read release notes file from the remote if necessary

### DIFF
--- a/src/main/java/fabric/beta/publisher/FabricBetaPublisher.java
+++ b/src/main/java/fabric/beta/publisher/FabricBetaPublisher.java
@@ -119,7 +119,7 @@ public class FabricBetaPublisher extends Recorder implements SimpleBuildStep {
         }
 
         String releaseNotes = getReleaseNotes(
-                changeLogSet, releaseNotesType, releaseNotesParameter, releaseNotesFile, environment);
+                changeLogSet, releaseNotesType, releaseNotesParameter, releaseNotesFile, environment, workspace);
 
         EnvVarsAction envVarsAction = null;
         if (!Strings.isNullOrEmpty(organization)) {

--- a/src/main/java/fabric/beta/publisher/ReleaseNotesFormatter.java
+++ b/src/main/java/fabric/beta/publisher/ReleaseNotesFormatter.java
@@ -1,17 +1,17 @@
 package fabric.beta.publisher;
 
 import hudson.EnvVars;
+import hudson.FilePath;
 import hudson.scm.ChangeLogSet;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 
 import static fabric.beta.publisher.FabricBetaPublisher.*;
 
 class ReleaseNotesFormatter {
     static String getReleaseNotes(ChangeLogSet<? extends ChangeLogSet.Entry> changeLogSet, String releaseNotesType,
-                                  String releaseNotesParameter, String releaseNotesFile, EnvVars environment)
+                                  String releaseNotesParameter, String releaseNotesFile, EnvVars environment,
+                                  FilePath workspace)
             throws IOException, InterruptedException {
         switch (releaseNotesType) {
             case RELEASE_NOTES_TYPE_NONE:
@@ -32,12 +32,10 @@ class ReleaseNotesFormatter {
                 }
                 return sb.toString();
             case RELEASE_NOTES_TYPE_FILE:
-                String releaseNotesFilePath = environment.expand(releaseNotesFile);
-                byte[] fileContent = Files.readAllBytes(Paths.get(releaseNotesFilePath));
-                return new String(fileContent, "UTF-8");
+                FilePath releaseNotesFilePath = new FilePath(workspace, environment.expand(releaseNotesFile));
+                return releaseNotesFilePath.readToString();
             default:
                 return null;
         }
     }
-
 }

--- a/src/main/resources/fabric/beta/publisher/FabricBetaPublisher/config.jelly
+++ b/src/main/resources/fabric/beta/publisher/FabricBetaPublisher/config.jelly
@@ -59,7 +59,7 @@
                       checked="${instance.isReleaseNotesType('RELEASE_NOTES_FILE')}" inline="true">
             <f:nested>
                 <f:entry title="Changelog file path" field="releaseNotesFile">
-                    <f:textbox default="$WORKSPACE/release_notes.txt"/>
+                    <f:textbox default="release_notes.txt"/>
                 </f:entry>
             </f:nested>
         </f:radioBlock>


### PR DESCRIPTION
This change will break things for people who use the "Release notes from file" option. Before it required an absolute path and now it will require a relative (to the workspace) path.