### PR TITLE
Add ci.jenkins.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,5 @@
+/* step provided by: https://github.com/jenkins-infra/pipeline-library */
+buildPlugin(
+    platforms: ['linux'],
+    findbugs: [run: true, archive: true]
+)


### PR DESCRIPTION
### What has been done
- Replaced Travis CI (https://travis-ci.org/) with Jenkins CI (https://ci.jenkins.io/).
- Preserved Findbugs step ([check how others run it on jenkins.io](https://github.com/search?q=org%3Ajenkinsci+buildPlugin%28platforms%3A+%5B%27linux%27%5D%2C+findbugs%3A+%5Brun%3A+true%5D%29&type=Code))

### Reason
- Building Jenkins plugin on Jenkins ([jobs for other plugins on ci.jenkins.io](https://ci.jenkins.io/job/Plugins/))
- Avoid build limits on Travis - `The job exceeded the maximum time limit for jobs, and has been terminated.` ([failing build](https://travis-ci.org/jenkinsci/fabric-beta-publisher-plugin/builds/441043243))

### How to test
https://ci.jenkins.io/ performs a scan of every Jenkins plugin (check the logs [here](https://ci.jenkins.io/job/Plugins/computation/consoleFull)).
This is how logs looked like before integration 
```
Proposing fabric-beta-publisher-plugin
22:50:26 GitHub API Usage: Current quota has 1101 remaining (3 under budget). Next quota of 5000 in 13 min
22:50:26 Connecting to https://api.github.com using jenkinsadmin/****** (GitHub access token for jenkinsadmin)
Examining jenkinsci/fabric-beta-publisher-plugin

  Checking branches...
22:50:26 GitHub API Usage: Current quota has 1099 remaining (1 under budget). Next quota of 5000 in 13 min

  Getting remote branches...

    Checking branch master
      ‘Jenkinsfile’ not found
    Does not meet criteria
22:50:26 GitHub API Usage: Current quota has 1097 remaining (1 over budget). Next quota of 5000 in 13 min. Sleeping for 26 sec.
22:50:52 GitHub API Usage: Current quota has 1097 remaining (26 under budget). Next quota of 5000 in 13 min

  1 branches were processed

  Checking pull-requests...
22:50:52 GitHub API Usage: Current quota has 1097 remaining (26 under budget). Next quota of 5000 in 13 min

  Getting remote pull requests...

  0 pull requests were processed

Finished examining jenkinsci/fabric-beta-publisher-plugin
```